### PR TITLE
[Functions] Create a Generic Firestore Document Access Object

### DIFF
--- a/functions/src/@types/generics.d.ts
+++ b/functions/src/@types/generics.d.ts
@@ -1,0 +1,3 @@
+declare interface DatabaseNode {
+  id: string;
+}

--- a/functions/src/config/firebaseInitialization.ts
+++ b/functions/src/config/firebaseInitialization.ts
@@ -1,0 +1,10 @@
+import * as admin from "firebase-admin";
+
+// Initialize Firebase
+const firebaseApp = admin.initializeApp();
+
+// Configure the hackathon-specific directory for Firestore
+export const firebaseFirestore = firebaseApp
+  .firestore()
+  .collection("hackathons")
+  .doc("FreyHacks2022");

--- a/functions/src/firebase/genericFirebaseDAO.ts
+++ b/functions/src/firebase/genericFirebaseDAO.ts
@@ -1,0 +1,64 @@
+import { firebaseFirestore } from "../config/firebaseInitialization";
+import { logAndThrowError } from "../utils/errorHandlingUtils";
+import {
+  validateDocDoesNotExistFactory,
+  validateDocExistsFactory,
+} from "./validationUtils";
+
+const genericFirebaseDAO = <T extends DatabaseNode>(
+  objectType: string,
+  collectionName: string
+) => {
+  const firebaseCollection = firebaseFirestore.collection(collectionName);
+  const validateDocExists = validateDocExistsFactory(objectType);
+  const validateDocDoesNotExist = validateDocDoesNotExistFactory(objectType);
+
+  const createDocFirestore = async (data: T) => {
+    const docReference = firebaseCollection.doc(data.id);
+    const doc = await docReference.get();
+    validateDocDoesNotExist(doc);
+    await docReference.set(data).catch(logAndThrowError);
+    return data;
+  };
+
+  const readDocFirestore = async (docId: string) => {
+    const doc = await firebaseCollection
+      .doc(docId)
+      .get()
+      .catch(logAndThrowError);
+    validateDocExists(doc);
+    return doc.data() as T;
+  };
+
+  const listDocsFirestore = async () => {
+    const docs = await firebaseCollection.get().catch(logAndThrowError);
+
+    return docs.docs.map((doc) => {
+      return doc.data() as T;
+    });
+  };
+
+  const updateDocFirestore = async (data: T) => {
+    const docReference = firebaseCollection.doc(data.id);
+    const doc = await docReference.get();
+    validateDocExists(doc);
+    await docReference.update(data).catch(logAndThrowError);
+    return data;
+  };
+
+  const deleteDocFirestore = async (docId: string) => {
+    const data = await readDocFirestore(docId);
+    await firebaseCollection.doc(docId).delete().catch(logAndThrowError);
+    return data;
+  };
+
+  return {
+    createDocFirestore,
+    readDocFirestore,
+    listDocsFirestore,
+    updateDocFirestore,
+    deleteDocFirestore,
+  };
+};
+
+export default genericFirebaseDAO;

--- a/functions/src/firebase/validationUtils.ts
+++ b/functions/src/firebase/validationUtils.ts
@@ -1,0 +1,20 @@
+import {
+  resourceAlreadyExistsError,
+  resourceDoesNotExistsError,
+} from "../utils/errorHandlingUtils";
+
+export const validateDocExistsFactory =
+  (objectType: string) =>
+  (doc: FirebaseFirestore.DocumentSnapshot<FirebaseFirestore.DocumentData>) => {
+    if (!doc.exists) {
+      resourceDoesNotExistsError(objectType, doc.id);
+    }
+  };
+
+export const validateDocDoesNotExistFactory =
+  (objectType: string) =>
+  (doc: FirebaseFirestore.DocumentSnapshot<FirebaseFirestore.DocumentData>) => {
+    if (doc.exists) {
+      resourceAlreadyExistsError(objectType, doc.id);
+    }
+  };

--- a/functions/src/utils/errorHandlingUtils.ts
+++ b/functions/src/utils/errorHandlingUtils.ts
@@ -1,0 +1,14 @@
+import { logger } from "firebase-functions";
+
+export const logAndThrowError = (message: string) => {
+  logger.warn(message);
+  throw new ReferenceError(message);
+};
+
+export const resourceAlreadyExistsError = (objectType: string, id: string) => {
+  logAndThrowError(`There already exists a ${objectType} with id=${id}`);
+};
+
+export const resourceDoesNotExistsError = (objectType: string, id: string) => {
+  logAndThrowError(`No ${objectType} exists with id=${id}`);
+};


### PR DESCRIPTION
### Notes

Creates a generic Firestore Document Access Object. Just provide the object type name, the collection name, and the TypeScript Type, and the operations for create, read, list, update, and delete are already ready to go. Note that the rest of the logic still needs to be added in the resolvers, but this should be a code and time saver in the meantime.

### Issues

- Working on #5 
- Working on #8 
- Working on #11 
- Working on #14 
- Working on #17 
- Working on #20 