### PR TITLE
[Functions] Add Caching to Firebase Document Access Objects

### DIFF
--- a/functions/src/@types/generics.d.ts
+++ b/functions/src/@types/generics.d.ts
@@ -1,3 +1,8 @@
 declare interface DatabaseNode {
   id: string;
 }
+
+declare interface FirestoreCache<T> {
+  data: { [key: string]: T | undefined };
+  complete: boolean;
+}

--- a/functions/src/firebase/genericFirebaseDAO.ts
+++ b/functions/src/firebase/genericFirebaseDAO.ts
@@ -1,70 +1,96 @@
+import { logger } from "firebase-functions";
 import { firebaseFirestore } from "../config/firebaseInitialization";
 import { logAndThrowError } from "../utils/errorHandlingUtils";
 import {
   validateDocDoesNotExistFactory,
   validateDocExistsFactory,
 } from "./validationUtils";
-import { logger } from "firebase-functions";
 
 const genericFirebaseDAO = <T extends DatabaseNode>(
   objectType: string,
-  collectionName: string
+  collectionName: string,
+  cache: FirestoreCache<T>
 ) => {
   const firebaseCollection = firebaseFirestore.collection(collectionName);
-  const validateDocExists = validateDocExistsFactory(objectType);
-  const validateDocDoesNotExist = validateDocDoesNotExistFactory(objectType);
+  const validateDocExists = validateDocExistsFactory(objectType, cache);
+  const validateDocDoesNotExist = validateDocDoesNotExistFactory(
+    objectType,
+    cache
+  );
 
   const createDocFirestore = async (data: T): Promise<T> => {
-    logger.info(`Creating ${objectType} with id=${data.id} in Firestore`);
+    logger.info(`Creating ${objectType} with id=${data.id} in Firestore.`);
     const docReference = firebaseCollection.doc(data.id);
-    const doc = await docReference.get();
-    validateDocDoesNotExist(doc);
+    await validateDocDoesNotExist(docReference);
     await docReference
       // Clean undefined fields
       // https://stackoverflow.com/questions/42310950/handling-undefined-values-with-firebase
       .set(JSON.parse(JSON.stringify(data)))
       .catch(logAndThrowError);
+    cache.data[data.id] = data; // Update the cache
     return data;
   };
 
   const readDocFirestore = async (docId: string): Promise<T> => {
-    logger.info(`Reading ${objectType} with id=${docId} in Firestore`);
-    const doc = await firebaseCollection
-      .doc(docId)
-      .get()
-      .catch(logAndThrowError);
-    validateDocExists(doc);
-    return doc.data() as T;
+    const cachedData = cache.data[docId];
+    if (cachedData !== undefined) {
+      // Cache Hit
+      logger.info(`Reading ${objectType} with id=${docId} from cache.`);
+      return cachedData;
+    } else {
+      // Cache Miss
+      logger.info(`Reading ${objectType} with id=${docId} from Firestore.`);
+      const docReference = await firebaseCollection.doc(docId);
+      await validateDocExists(docReference);
+      // Provided validation does not fail, the doc is now in the cache due to getting it during validation
+      return cache.data[docId] as T;
+    }
   };
 
   const listDocsFirestore = async (): Promise<T[]> => {
-    logger.info(
-      `Listing all documents of object type ${objectType} in Firestore`
-    );
-    const docs = await firebaseCollection.get().catch(logAndThrowError);
+    if (cache.complete) {
+      // Cache already contains the full list of all documents
+      logger.info(
+        `Listing all documents of object type ${objectType} in cache.`
+      );
+      const docIds = Object.keys(cache.data);
+      return docIds.map((docId) => {
+        return cache.data[docId] as T; // The cache always contains a document if the key exists
+      });
+    } else {
+      // Cache does not already contain the full list
+      logger.info(
+        `Listing all documents of object type ${objectType} in Firestore.`
+      );
+      cache.complete = true;
+      const docs = await firebaseCollection.get().catch(logAndThrowError);
 
-    return docs.docs.map((doc) => {
-      return doc.data() as T;
-    });
+      return docs.docs.map((doc) => {
+        const docData = doc.data() as T;
+        cache.data[doc.id] = docData; // Update the cache
+        return docData;
+      });
+    }
   };
 
   const updateDocFirestore = async (data: T): Promise<T> => {
-    logger.info(`Updating ${objectType} with id=${data.id} in Firestore`);
+    logger.info(`Updating ${objectType} with id=${data.id} in Firestore.`);
     const docReference = firebaseCollection.doc(data.id);
-    const doc = await docReference.get();
-    validateDocExists(doc);
+    await validateDocExists(docReference);
     await docReference
       // Clean undefined fields
       // https://stackoverflow.com/questions/42310950/handling-undefined-values-with-firebase
       .update(JSON.parse(JSON.stringify(data)))
       .catch(logAndThrowError);
+    cache.data[data.id] = data; // Update the cache
     return data;
   };
 
   const deleteDocFirestore = async (docId: string): Promise<T> => {
-    logger.info(`Deleting ${objectType} with id=${docId} in Firestore`);
-    const data = await readDocFirestore(docId);
+    logger.info(`Deleting ${objectType} with id=${docId} in Firestore.`);
+    const data = await readDocFirestore(docId); // Validation occurs here
     await firebaseCollection.doc(docId).delete().catch(logAndThrowError);
+    delete cache.data[docId]; // Remove from the cache
     return data;
   };
 

--- a/functions/src/firebase/mediaObjectsDAO.ts
+++ b/functions/src/firebase/mediaObjectsDAO.ts
@@ -1,8 +1,10 @@
 import genericFirebaseDAO from "./genericFirebaseDAO";
 
+const cache: FirestoreCache<MediaObjectData> = { data: {}, complete: false };
 const mediaObjectsDAO = genericFirebaseDAO<MediaObjectData>(
   "media object",
-  "media"
+  "media",
+  cache
 );
 
 // Generic DAO Functions

--- a/functions/src/firebase/playlistsDAO.ts
+++ b/functions/src/firebase/playlistsDAO.ts
@@ -1,6 +1,11 @@
 import genericFirebaseDAO from "./genericFirebaseDAO";
 
-const playlistsDAO = genericFirebaseDAO<PlaylistData>("playlist", "playlists");
+const cache: FirestoreCache<PlaylistData> = { data: {}, complete: false };
+const playlistsDAO = genericFirebaseDAO<PlaylistData>(
+  "playlist",
+  "playlists",
+  cache
+);
 
 // Generic DAO Functions
 export const createPlaylistFirestore = playlistsDAO.createDocFirestore;

--- a/functions/src/firebase/tagsDAO.ts
+++ b/functions/src/firebase/tagsDAO.ts
@@ -1,6 +1,7 @@
 import genericFirebaseDAO from "./genericFirebaseDAO";
 
-const tagsDAO = genericFirebaseDAO<TagData>("tag", "tags");
+const cache: FirestoreCache<TagData> = { data: {}, complete: false };
+const tagsDAO = genericFirebaseDAO<TagData>("tag", "tags", cache);
 
 // Generic DAO Functions
 export const createTagFirestore = tagsDAO.createDocFirestore;

--- a/functions/src/firebase/validationUtils.ts
+++ b/functions/src/firebase/validationUtils.ts
@@ -1,20 +1,42 @@
 import {
+  logAndThrowError,
   resourceAlreadyExistsError,
   resourceDoesNotExistsError,
 } from "../utils/errorHandlingUtils";
 
 export const validateDocExistsFactory =
-  (objectType: string) =>
-  (doc: FirebaseFirestore.DocumentSnapshot<FirebaseFirestore.DocumentData>) => {
-    if (!doc.exists) {
-      resourceDoesNotExistsError(objectType, doc.id);
+  <T>(objectType: string, cache: FirestoreCache<T>) =>
+  async (
+    docReference: FirebaseFirestore.DocumentReference<FirebaseFirestore.DocumentData>
+  ) => {
+    // Check if the document already exists in the cache; if so, it already exists
+    if (!cache.data[docReference.id]) {
+      // Check if the document exists in Firestore
+      const doc = await docReference.get().catch(logAndThrowError);
+      if (!doc.exists) {
+        resourceDoesNotExistsError(objectType, doc.id);
+      } else {
+        const docData = doc.data() as T;
+        cache.data[doc.id] = docData; // Update the cache
+      }
     }
   };
 
 export const validateDocDoesNotExistFactory =
-  (objectType: string) =>
-  (doc: FirebaseFirestore.DocumentSnapshot<FirebaseFirestore.DocumentData>) => {
+  <T>(objectType: string, cache: FirestoreCache<T>) =>
+  async (
+    docReference: FirebaseFirestore.DocumentReference<FirebaseFirestore.DocumentData>
+  ) => {
+    // Check if the document already exists in the cache; if so, it already exists!
+    if (!!cache.data[docReference.id]) {
+      resourceAlreadyExistsError(objectType, docReference.id);
+    }
+
+    // Check if the document exists in Firestore
+    const doc = await docReference.get().catch(logAndThrowError);
     if (doc.exists) {
+      const docData = doc.data() as T;
+      cache.data[doc.id] = docData; // Update the cache
       resourceAlreadyExistsError(objectType, doc.id);
     }
   };

--- a/functions/src/graphql/mediaObjects/mutations.ts
+++ b/functions/src/graphql/mediaObjects/mutations.ts
@@ -12,10 +12,8 @@ const createMediaObject = async ({
   logger.info(
     `Running Mutation: createMediaObject(input: ${JSON.stringify(input)})`
   );
-  const { mediaObjectData, cachedTabs } = await createMediaObjectFromInput(
-    input
-  );
-  return convertMediaObjectDataToMediaObject(mediaObjectData, cachedTabs);
+  const mediaObjectData = await createMediaObjectFromInput(input);
+  return convertMediaObjectDataToMediaObject(mediaObjectData);
 };
 
 const updateMediaObject = async ({
@@ -24,10 +22,8 @@ const updateMediaObject = async ({
   logger.info(
     `Running Mutation: updateMediaObject(input: ${JSON.stringify(input)})`
   );
-  const { mediaObjectData, cachedTabs } = await updateMediaObjectFromInput(
-    input
-  );
-  return convertMediaObjectDataToMediaObject(mediaObjectData, cachedTabs);
+  const mediaObjectData = await updateMediaObjectFromInput(input);
+  return convertMediaObjectDataToMediaObject(mediaObjectData);
 };
 
 const deleteMediaObject = async ({
@@ -36,10 +32,8 @@ const deleteMediaObject = async ({
   logger.info(
     `Running Mutation: deleteMediaObject(input: ${JSON.stringify(input)})`
   );
-  const { mediaObjectData, cachedTabs } = await deleteMediaObjectFromInput(
-    input
-  );
-  return convertMediaObjectDataToMediaObject(mediaObjectData, cachedTabs);
+  const mediaObjectData = await deleteMediaObjectFromInput(input);
+  return convertMediaObjectDataToMediaObject(mediaObjectData);
 };
 
 export const mutations = {

--- a/functions/src/graphql/tags/mutations.ts
+++ b/functions/src/graphql/tags/mutations.ts
@@ -17,8 +17,8 @@ const deleteTag = async ({
   input,
 }: GraphqlMutationInput<DeleteTagInput>): Promise<Tag> => {
   logger.info(`Running Mutation: deleteTag(input: ${JSON.stringify(input)})`);
-  const { tagData, cachedMediaObjects } = await deleteTagFromInput(input);
-  return convertTagDataToTag(tagData, { mediaObjectsData: cachedMediaObjects });
+  const tagData = await deleteTagFromInput(input);
+  return convertTagDataToTag(tagData);
 };
 
 export const mutations = {


### PR DESCRIPTION
### Notes

This moves caching to the Generic Firebase Document Access Model, so it happens automatically, and the Firebase DAO can always be called to get objects from the database, and the fastes/cheapest copy of them will always be returned.

### Testing

#### Mutation Operations

**Query:**

```graphql
mutation {
  createTag(input: {
    name: "Cache Test Tag"
  }) {
    id
    name
    type
  }
  
  deleteTag(input: {
    id: "TAG_CUSTOM_cache-test-tag"
  }) {
    id
    name
    type
  }
  
  recreateTag: createTag(input: {
    name: "Cache Test Tag"
  }) {
    id
    name
    type
  }
}
```

**Results:**

```json
{
  "data": {
    "createTag": {
      "id": "TAG_CUSTOM_cache-test-tag",
      "name": "Cache Test Tag",
      "type": "CUSTOM"
    },
    "deleteTag": {
      "id": "TAG_CUSTOM_cache-test-tag",
      "name": "Cache Test Tag",
      "type": "CUSTOM"
    },
    "recreateTag": {
      "id": "TAG_CUSTOM_cache-test-tag",
      "name": "Cache Test Tag",
      "type": "CUSTOM"
    }
  }
}
```

**Logs:**

```
04:05:08 I function[us-central1-media_metadata_manager] Beginning execution of "media_metadata_manager"
04:05:08 I function[us-central1-media_metadata_manager] { "severity": "INFO", "message": "Running Mutation: createTag(input: {\"name\":\"Cache Test Tag\"})" }
04:05:08 I function[us-central1-media_metadata_manager] { "severity": "INFO", "message": "Creating tag with id=TAG_CUSTOM_cache-test-tag in Firestore." }
04:05:09 I function[us-central1-media_metadata_manager] { "severity": "INFO", "message": "Running Mutation: deleteTag(input: {\"id\":\"TAG_CUSTOM_cache-test-tag\"})" }
04:05:09 I function[us-central1-media_metadata_manager] { "severity": "INFO", "message": "Deleting tag with id=TAG_CUSTOM_cache-test-tag in Firestore." }
04:05:09 I function[us-central1-media_metadata_manager] { "severity": "INFO", "message": "Reading tag with id=TAG_CUSTOM_cache-test-tag from cache." }
04:05:09 I function[us-central1-media_metadata_manager] { "severity": "INFO", "message": "Running Mutation: createTag(input: {\"name\":\"Cache Test Tag\"})" }
04:05:09 I function[us-central1-media_metadata_manager] { "severity": "INFO", "message": "Creating tag with id=TAG_CUSTOM_cache-test-tag in Firestore." }
04:05:09 I function[us-central1-media_metadata_manager] Finished "media_metadata_manager" in ~1s
```

**Notes:**

From the logs we can see that the creation did in fact store the data in the cache, since it was read from the cache upon read. We also know that the delete operaiton removed it from the cache, or else we would have had an already exists exception since we check the cache during validation upon the recreation of the tag.

#### Query Operations

**Query:**

```graphql
query {
  tags {
    id
  }
  detailedTags: tags{
    id
    name
    type
  }
  tag(id: "TAG_CUSTOM_cache-test-tag") {
    id
  }
  playlist(id: "PLAYLIST_6a828595-db1e-4680-a39c-b77fa3011ae2") {
    id
  }
}
```

**Results:**

```json
{
  "data": {
    "tags": [
      {
        "id": "TAG_CUSTOM_cache-test-tag"
      },
      {
        "id": "TAG_CREATOR_noah-kahan"
      },
      {
        "id": "TAG_CUSTOM_test2"
      },
      {
        "id": "TAG_CUSTOM_test3"
      },
      {
        "id": "TAG_CUSTOM_test4"
      },
      {
        "id": "TAG_CUSTOM_test5"
      },
      {
        "id": "TAG_GENRE_pop"
      },
      {
        "id": "TAG_SPECIAL_loop"
      }
    ],
    "detailedTags": [
      {
        "id": "TAG_CUSTOM_cache-test-tag",
        "name": "Cache Test Tag",
        "type": "CUSTOM"
      },
      {
        "id": "TAG_CREATOR_noah-kahan",
        "name": "Noah Kahan",
        "type": "CREATOR"
      },
      {
        "id": "TAG_CUSTOM_test2",
        "name": "Test2",
        "type": "CUSTOM"
      },
      {
        "id": "TAG_CUSTOM_test3",
        "name": "Test3",
        "type": "CUSTOM"
      },
      {
        "id": "TAG_CUSTOM_test4",
        "name": "Test4",
        "type": "CUSTOM"
      },
      {
        "id": "TAG_CUSTOM_test5",
        "name": "Test5",
        "type": "CUSTOM"
      },
      {
        "id": "TAG_GENRE_pop",
        "name": "Pop",
        "type": "GENRE"
      },
      {
        "id": "TAG_SPECIAL_loop",
        "name": "Loop",
        "type": "SPECIAL"
      }
    ],
    "tag": {
      "id": "TAG_CUSTOM_cache-test-tag"
    },
    "playlist": {
      "id": "PLAYLIST_6a828595-db1e-4680-a39c-b77fa3011ae2"
    }
  }
}
```

**Logs:**

```
04:12:34 I function[us-central1-media_metadata_manager] Beginning execution of "media_metadata_manager"
04:12:34 I function[us-central1-media_metadata_manager] { "severity": "INFO", "message": "Running Query: tags" }
04:12:34 I function[us-central1-media_metadata_manager] { "severity": "INFO", "message": "Listing all documents of object type tag in Firestore." }
04:12:34 I function[us-central1-media_metadata_manager] { "severity": "INFO", "message": "Running Query: tags" }
04:12:34 I function[us-central1-media_metadata_manager] { "severity": "INFO", "message": "Listing all documents of object type tag in cache." }
04:12:34 I function[us-central1-media_metadata_manager] { "severity": "INFO", "message": "Running Query: tag(id=TAG_CUSTOM_cache-test-tag)" }
04:12:34 I function[us-central1-media_metadata_manager] { "severity": "INFO", "message": "Reading tag with id=TAG_CUSTOM_cache-test-tag from cache." }
04:12:34 I function[us-central1-media_metadata_manager] { "severity": "INFO", "message": "Running Query: playlist(id=PLAYLIST_6a828595-db1e-4680-a39c-b77fa3011ae2)" }
04:12:34 I function[us-central1-media_metadata_manager] { "severity": "INFO", "message": "Reading playlist with id=PLAYLIST_6a828595-db1e-4680-a39c-b77fa3011ae2 from Firestore." }
04:12:34 I function[us-central1-media_metadata_manager] Finished "media_metadata_manager" in ~1s
```

**Notes:**

While reading an items one by one then the list will not result in any performance improvements, this confirms that once the back end caches the list once, any subsequent lists or reads will pull from the cache.

Likewise, this proves that if we need to get the document to check if it exists or not, that is sufficent to return the document from the cache, and we don't need to get it again.

### Issues

- Closes #30