### PR TITLE
[Website] Initialize Data for the Website

### DIFF
--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -28,7 +28,11 @@
         "react-scripts": "5.0.1",
         "styled-components": "^5.3.5",
         "typescript": "^4.7.4",
+        "uuid": "^8.3.2",
         "web-vitals": "^2.1.4"
+      },
+      "devDependencies": {
+        "@types/uuid": "^8.3.4"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -4893,6 +4897,12 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.2.tgz",
       "integrity": "sha512-F5DIZ36YVLE+PN+Zwws4kJogq47hNgX3Nx6WyDJ3kcplxyke3XIzB8uK5n/Lpm1HBsbGzd6nmGehL8cPekP+Tg=="
+    },
+    "node_modules/@types/uuid": {
+      "version": "8.3.4",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.4.tgz",
+      "integrity": "sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw==",
+      "dev": true
     },
     "node_modules/@types/ws": {
       "version": "8.5.3",
@@ -21304,6 +21314,12 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.2.tgz",
       "integrity": "sha512-F5DIZ36YVLE+PN+Zwws4kJogq47hNgX3Nx6WyDJ3kcplxyke3XIzB8uK5n/Lpm1HBsbGzd6nmGehL8cPekP+Tg=="
+    },
+    "@types/uuid": {
+      "version": "8.3.4",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.4.tgz",
+      "integrity": "sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw==",
+      "dev": true
     },
     "@types/ws": {
       "version": "8.5.3",

--- a/website/package.json
+++ b/website/package.json
@@ -23,6 +23,7 @@
     "react-scripts": "5.0.1",
     "styled-components": "^5.3.5",
     "typescript": "^4.7.4",
+    "uuid": "^8.3.2",
     "web-vitals": "^2.1.4"
   },
   "scripts": {
@@ -48,5 +49,8 @@
       "last 1 firefox version",
       "last 1 safari version"
     ]
+  },
+  "devDependencies": {
+    "@types/uuid": "^8.3.4"
   }
 }

--- a/website/src/@types/mediaObjects.d.ts
+++ b/website/src/@types/mediaObjects.d.ts
@@ -1,0 +1,56 @@
+// Interfaces
+declare interface MediaObject {
+  id: string;
+  name: string;
+  allTagIds: string[];
+  creatorTagIds: string[];
+  genreTagIds: string[];
+  customTagIds: string[];
+  specialTagIds: string[];
+  externalResources?: MediaObjectExternalResource[];
+  sources: MediaObjectSource[];
+  playlistIds: string[];
+}
+
+// GraphQL Inputs
+declare interface CreateMediaObjectInput {
+  name: string;
+  creatorTagIdsOrNames?: string[];
+  genreTagIdsOrNames?: string[];
+  customTagIdsOrNames?: string[];
+  specialTagIdsOrNames?: string[];
+  externalResources?: MediaObjectExternalResource[];
+  sources: MediaObjectSource[];
+}
+
+declare interface UpdateMediaObjectInput {
+  id: string;
+  name?: string;
+  creatorTagIdsOrNames?: string[];
+  genreTagIdsOrNames?: string[];
+  customTagIdsOrNames?: string[];
+  specialTagIdsOrNames?: string[];
+  externalResources?: MediaObjectExternalResource[];
+  sources?: MediaObjectSource[];
+}
+
+declare interface DeleteMediaObjectInput {
+  id: string;
+}
+
+// Enums and Subtypes
+declare interface MediaObjectExternalResource {
+  name: string;
+  url: string;
+}
+
+declare interface MediaObjectSource {
+  type: MediaObjectSourceType;
+  source: MediaObjectSourceSource;
+  url?: string;
+  externalId?: string;
+}
+
+declare type MediaObjectSourceType = "VIDEO" | "SONG" | "MUSIC_VIDEO" | "OTHER";
+
+declare type MediaObjectSourceSource = "LINK"; // | PlaylistExternalPlatforms;

--- a/website/src/@types/playlists.d.ts
+++ b/website/src/@types/playlists.d.ts
@@ -1,0 +1,27 @@
+// Interfaces
+declare interface Playlist {
+  id: string;
+  name: string;
+  description: string;
+  filter: string;
+  tagIds: string[];
+  mediaObjectIds: string[];
+}
+
+// GraphQL Inputs
+declare interface CreatePlaylistInput {
+  name: string;
+  description: string;
+  filter: string;
+}
+
+declare interface UpdatePlaylistInput {
+  id: string;
+  name?: string;
+  description?: string;
+  filter?: string;
+}
+
+declare interface DeletePlaylistInput {
+  id: string;
+}

--- a/website/src/@types/tags.d.ts
+++ b/website/src/@types/tags.d.ts
@@ -1,0 +1,29 @@
+// Interfaces
+declare interface Tag {
+  id: string;
+  name: string;
+  type: TagType;
+  mediaObjectIds: string[];
+  playlistIds: string[];
+}
+
+// GraphQL Inputs
+declare interface CreateTagInput {
+  name: string;
+  type?: TagType;
+}
+
+declare interface DeleteTagInput {
+  id: string;
+}
+
+// Enums and Subtypes
+declare type TagType = "SPECIAL" | "CREATOR" | "GENRE" | "CUSTOM";
+
+// Front end specific
+declare type PseudoTagType = TagType | "ALBUM" | "LINK";
+
+declare interface PseudoTag extends Tag {
+  type: PseudoTagType;
+  url?: string;
+}

--- a/website/src/cache/cacheFactory.ts
+++ b/website/src/cache/cacheFactory.ts
@@ -1,0 +1,62 @@
+export const cacheFactory = <T>() => {
+  let initialized = false;
+  const cache: { [key: string]: T } = {};
+
+  const getItem = (key: string) => {
+    return cache[key];
+  };
+
+  const listItems = () => {
+    return Object.keys(cache).map((key) => {
+      return getItem(key);
+    });
+  };
+
+  const upsertItem = (updateStateHook: () => void, key: string, value: T) => {
+    cache[key] = value;
+    updateStateHook();
+  };
+
+  const deleteItem = (updateStateHook: () => void, key: string) => {
+    delete cache[key];
+    updateStateHook();
+  };
+
+  const initializeCache = (
+    updateStateHook: () => void,
+    initialCacheData: { key: string; value: T }[],
+    force?: boolean
+  ) => {
+    if (!initialized || force) {
+      initialized = true;
+      initialCacheData.map(({ key, value }) => {
+        // Don't update the state after each upsert to reduce re-renders
+        return upsertItem(() => {}, key, value);
+      });
+      updateStateHook();
+    }
+  };
+
+  const clearCache = (updateStateHook: () => void) => {
+    initialized = false;
+    Object.keys(cache).map((key) => {
+      // Don't update the state after each delete to reduce re-renders
+      return deleteItem(() => [], key);
+    });
+    updateStateHook();
+  };
+
+  const isInitialized = () => {
+    return initialized;
+  };
+
+  return {
+    getItem,
+    listItems,
+    upsertItem,
+    deleteItem,
+    initializeCache,
+    clearCache,
+    isInitialized,
+  };
+};

--- a/website/src/cache/mediaObjectsCache.ts
+++ b/website/src/cache/mediaObjectsCache.ts
@@ -1,0 +1,11 @@
+import { cacheFactory } from "./cacheFactory";
+
+const cache = cacheFactory<MediaObject>();
+
+export const getMediaObjectFromCache = cache.getItem;
+export const listMediaObjectsInCache = cache.listItems;
+export const upsertMediaObjectToCache = cache.upsertItem;
+export const deleteMediaObjectFromCache = cache.getItem;
+export const initializeMediaObjectsCache = cache.initializeCache;
+export const clearMediaObjectsCache = cache.clearCache;
+export const isMediaObjectsCacheInitialized = cache.isInitialized;

--- a/website/src/cache/playlistsCache.ts
+++ b/website/src/cache/playlistsCache.ts
@@ -1,0 +1,11 @@
+import { cacheFactory } from "./cacheFactory";
+
+const cache = cacheFactory<Playlist>();
+
+export const getPlaylistFromCache = cache.getItem;
+export const listPlaylistsInCache = cache.listItems;
+export const upsertPlaylistToCache = cache.upsertItem;
+export const deletePlaylistFromCache = cache.getItem;
+export const initializePlaylistsCache = cache.initializeCache;
+export const clearPlaylistsCache = cache.clearCache;
+export const isPlaylistCacheInitialized = cache.isInitialized;

--- a/website/src/cache/tagsCache.ts
+++ b/website/src/cache/tagsCache.ts
@@ -1,0 +1,11 @@
+import { cacheFactory } from "./cacheFactory";
+
+const cache = cacheFactory<Tag>();
+
+export const getTagFromCache = cache.getItem;
+export const listTagsInCache = cache.listItems;
+export const upsertTagToCache = cache.upsertItem;
+export const deleteTagFromCache = cache.getItem;
+export const initializeTagsCache = cache.initializeCache;
+export const clearTagsCache = cache.clearCache;
+export const isTagsCacheInitialized = cache.isInitialized;

--- a/website/src/components/data/DataInitializer.tsx
+++ b/website/src/components/data/DataInitializer.tsx
@@ -1,0 +1,86 @@
+import React, { Fragment } from "react";
+import { v4 as uuid } from "uuid";
+import { initializeMediaObjectsCache } from "../../cache/mediaObjectsCache";
+import { initializePlaylistsCache } from "../../cache/playlistsCache";
+import { initializeTagsCache } from "../../cache/tagsCache";
+import { graphqlClient } from "../../config/graphqlClient";
+import { initializeAllDataQueryString } from "../../graphql/graphqlQueries";
+import AlertsManagerContext from "../miscellaneous/alertsManager/AlertsManagerContext";
+import LoadingScreenContext from "../miscellaneous/loadingScreen/LoadingScreenContext";
+
+// Define a TypeScript Type for the DataInitializer Props
+declare type DataInitializerProps = {};
+
+// Concurrency lock to prevent duplicate calls
+let initialized = false;
+let latestRequestTag: string = "";
+
+/**
+ * Data Initializer
+ * @description A central class to initialize cache data for the website.
+ */
+const DataInitializer: React.FunctionComponent<DataInitializerProps> = () => {
+  const setLoadingMessage =
+    React.useContext(LoadingScreenContext).setLoadingMessage;
+
+  const addAlertMessage =
+    React.useContext(AlertsManagerContext).addAlertMessage;
+
+  const convertToKeyValuePair = <T extends { id: string }>(data: T[]) => {
+    return data.map((item) => {
+      return { key: item.id, value: item };
+    });
+  };
+
+  // Initialize Data
+  if (!initialized) {
+    initialized = true;
+    // The short delay ensures that only one component is updating state at once.
+    setTimeout(() => {
+      setLoadingMessage("Fetching data...");
+      // The short delay ensures only one request is sent.
+      const currentRequestTag = uuid();
+      latestRequestTag = currentRequestTag;
+      setTimeout(() => {
+        // Check that the current request is the latest request
+        if (currentRequestTag === latestRequestTag) {
+          graphqlClient
+            .request(initializeAllDataQueryString)
+            .then(({ tags, mediaObjects, playlists }) => {
+              initializeTagsCache(() => [], convertToKeyValuePair(tags));
+              initializeMediaObjectsCache(
+                () => [],
+                convertToKeyValuePair(mediaObjects)
+              );
+              initializePlaylistsCache(
+                () => [],
+                convertToKeyValuePair(playlists)
+              );
+              addAlertMessage({
+                severity: "success",
+                title: "Success: Data Initialization Complete",
+                message:
+                  "All date from the database has been loaded successfully.",
+              });
+            })
+            .catch((error) => {
+              console.error(error);
+              addAlertMessage({
+                severity: "error",
+                title: "Error: Unable to Initialize Data",
+                message: error,
+              });
+            })
+            .finally(() => {
+              // The short delay is to give the components time to render
+              setTimeout(() => setLoadingMessage(""), 100);
+            });
+        }
+      }, 100);
+    }, 1);
+  }
+
+  return <Fragment />;
+};
+
+export default DataInitializer;

--- a/website/src/components/data/DataManager.tsx
+++ b/website/src/components/data/DataManager.tsx
@@ -1,0 +1,35 @@
+import React, { ReactNode } from "react";
+import DataInitializer from "./DataInitializer";
+import DataUpdateHookContext from "./DataUpdateHookContext";
+
+// Define a TypeScript Type for the DataManager Props
+// Matches declaration of the children props from the React Fragment definition
+declare type DataManagerProps = {
+  children?: ReactNode | undefined;
+};
+
+/**
+ * Data Manager
+ * @description A central class to manage the state for when the cache was last updated.
+ */
+const DataManager: React.FunctionComponent<DataManagerProps> = ({
+  children,
+}) => {
+  const [cacheUpdatedAt, setCacheUpdatedAt] = React.useState<number>(0);
+
+  const dataUpdated = () => {
+    setCacheUpdatedAt(Date.now());
+  };
+
+  // Use the updatedAt field to eat the "@typescript-eslint/no-unused-vars" error
+  (() => cacheUpdatedAt)();
+
+  return (
+    <DataUpdateHookContext.Provider value={{ dataUpdated }}>
+      <DataInitializer />
+      {children}
+    </DataUpdateHookContext.Provider>
+  );
+};
+
+export default DataManager;

--- a/website/src/components/data/DataUpdateHookContext.tsx
+++ b/website/src/components/data/DataUpdateHookContext.tsx
@@ -1,0 +1,17 @@
+import React from "react";
+
+// Define a TypeScript Type for the DataUpdateHookContext
+export declare type DataUpdateHookContextType = {
+  dataUpdated: () => void;
+};
+
+// Defines a context provider for the alert message information; prevents needing to pass it via props
+const DataUpdateHookContext = React.createContext<DataUpdateHookContextType>({
+  dataUpdated: () => {
+    console.log(
+      "No Provider found for the DataUpdateHookContext. Please check this call was from within a Provider."
+    );
+  },
+});
+
+export default DataUpdateHookContext;

--- a/website/src/components/helper/ContextWrapper.tsx
+++ b/website/src/components/helper/ContextWrapper.tsx
@@ -1,6 +1,7 @@
 import React, { ReactNode } from "react";
 import { BrowserRouter as Router } from "react-router-dom";
 import CustomThemeProvider from "../../styles/CustomThemeProvider";
+import DataManager from "../data/DataManager";
 import AlertsManager from "../miscellaneous/alertsManager/AlertsManager";
 import LoadingScreen from "../miscellaneous/loadingScreen/LoadingScreen";
 
@@ -23,9 +24,11 @@ const ContextWrapper: React.FunctionComponent<ContextWrapperProps> = ({
   return (
     <CustomThemeProvider>
       <Router>
-        {menuAppBar}
         <LoadingScreen>
-          <AlertsManager>{children}</AlertsManager>
+          {menuAppBar}
+          <AlertsManager>
+            <DataManager>{children}</DataManager>
+          </AlertsManager>
         </LoadingScreen>
       </Router>
     </CustomThemeProvider>

--- a/website/src/components/miscellaneous/alertsManager/AlertsManager.tsx
+++ b/website/src/components/miscellaneous/alertsManager/AlertsManager.tsx
@@ -53,6 +53,9 @@ const AlertsManager: React.FunctionComponent<AlertsManagerProps> = ({
     setUpdatedAt(Date.now());
   };
 
+  // Use the updatedAt field to eat the "@typescript-eslint/no-unused-vars" error
+  (() => updatedAt)();
+
   return (
     <AlertsManagerContext.Provider value={{ addAlertMessage }}>
       <Container>

--- a/website/src/components/miscellaneous/alertsManager/AlertsManagerContext.tsx
+++ b/website/src/components/miscellaneous/alertsManager/AlertsManagerContext.tsx
@@ -16,7 +16,7 @@ export declare type AlertsManagerContextType = {
 const AlertsManagerContext = React.createContext<AlertsManagerContextType>({
   addAlertMessage: () => {
     console.log(
-      "No Provider found for the AlertManagerContext. Please check this call was from within a Provider."
+      "No Provider found for the AlertsManagerContext. Please check this call was from within a Provider."
     );
   },
 });

--- a/website/src/components/miscellaneous/loadingScreen/LoadingScreen.tsx
+++ b/website/src/components/miscellaneous/loadingScreen/LoadingScreen.tsx
@@ -38,7 +38,8 @@ const LoadingScreen: React.FunctionComponent<LoadingScreenProps> = ({
   children,
 }) => {
   // Creates a state to keep track of the current loading message
-  const [loadingMessage, setLoadingMessage] = React.useState<string>("");
+  const [loadingMessage, setLoadingMessage] =
+    React.useState<string>("Fetching data...");
 
   return (
     <LoadingScreenContext.Provider value={{ setLoadingMessage }}>

--- a/website/src/graphql/graphqlQueries.ts
+++ b/website/src/graphql/graphqlQueries.ts
@@ -1,0 +1,24 @@
+import { gql } from "graphql-request";
+import {
+  mediaObjectReturnFieldsString,
+  playlistReturnFieldsString,
+  tagReturnFieldsString,
+} from "./returnDataFragments";
+
+export const initializeAllDataQueryString = gql`
+  query {
+    tags {
+      ...tagReturnFields
+    }
+    mediaObjects {
+      ...mediaObjectReturnFields
+    }
+    playlists {
+      ...playlistReturnFields
+    }
+  }
+
+  ${tagReturnFieldsString}
+  ${mediaObjectReturnFieldsString}
+  ${playlistReturnFieldsString}
+`;

--- a/website/src/graphql/returnDataFragments.ts
+++ b/website/src/graphql/returnDataFragments.ts
@@ -1,0 +1,45 @@
+import { gql } from "graphql-request";
+
+export const tagReturnFieldsString = gql`
+  fragment tagReturnFields on Tag {
+    id
+    name
+    type
+    mediaObjectIds
+    playlistIds
+  }
+`;
+
+export const mediaObjectReturnFieldsString = gql`
+  fragment mediaObjectReturnFields on MediaObject {
+    id
+    name
+    allTagIds
+    creatorTagIds
+    genreTagIds
+    customTagIds
+    specialTagIds
+    externalResources {
+      name
+      url
+    }
+    sources {
+      type
+      source
+      url
+      externalId
+    }
+    playlistIds
+  }
+`;
+
+export const playlistReturnFieldsString = gql`
+  fragment playlistReturnFields on Playlist {
+    id
+    name
+    description
+    filter
+    tagIds
+    mediaObjectIds
+  }
+`;


### PR DESCRIPTION
### Notes

Define the required TypeScript types, local data stores, GraphQL Queries, and React Components to cache all of the required data from the back end and API to the front end website. This provides a performance boost since once the data is loaded from the API once, we don't need to do any more reads. This saves billing time for the back end, Firestore calls, and latency on the front end.

### Testing

Local testing by running `npm run start` from the `/website/` directory.

### Issues

- Working on #6
- Working on #9
- Working on #12
- Working on #15
- Working on #18